### PR TITLE
Rename build_wheels workflow to match the other UBS repos

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,4 +1,4 @@
-name: Build and Publish PyPi (ubdcc-dashboard)
+name: Build and Publish GH+PyPi
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-dashboard.svg)](https://github.com/oliver-zehentleitner/ubdcc-dashboard/issues)
 [![CodeQL](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/codeql.yml/badge.svg)](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/codeql.yml)
 [![Unit Tests](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/unit-tests.yml)
-[![Build and Publish PyPi (ubdcc-dashboard)](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/build_wheels.yml)
+[![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/build_wheels.yml)
 [![Create GitHub Release](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/gh_release.yml/badge.svg)](https://github.com/oliver-zehentleitner/ubdcc-dashboard/actions/workflows/gh_release.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/ubdcc-dashboard/)
 [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://blog.technopathy.club/series/unicorn-binance-suite)


### PR DESCRIPTION
## Summary

Renames the workflow display name from `Build and Publish PyPi (ubdcc-dashboard)` to `Build and Publish GH+PyPi`, matching the other standalone UBS repos (UBTSL, UBWA, UBRA, UBLDC, unicorn-fy).

The package-suffixed variant is only used in the per-package UBDCC meta repo, which publishes five wheels from one repo. The dashboard ships a single package, so the generic name applies.

Updates the README badge label to track the renamed workflow (the URL is unchanged — still points at `build_wheels.yml`).

## Heads-up for #8

If PR #8 (full UBS footer) lands first, it keeps the old badge label; this PR then fixes it. If this PR lands first, #8 needs a trivial rebase on the badge line. Either order is fine.

## Test plan

- [ ] Badge label reads `Build and Publish GH+PyPi` on the GitHub README
- [ ] Workflow run shows the new display name in the Actions tab