### PR TITLE
README: drop UBDCC-cluster bullet from Related Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ REST API.
 
 ## Related Articles
 - [UNICORN Binance Suite Article Series](https://blog.technopathy.club/series/unicorn-binance-suite)
-- [The UNICORN Binance DepthCache Cluster project](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) — the server side the dashboard talks to.
 
 ## Project Homepage
 [https://github.com/oliver-zehentleitner/ubdcc-dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)


### PR DESCRIPTION
Removes the '[The UNICORN Binance DepthCache Cluster project] — the server side the dashboard talks to.' bullet from the Related Articles section.