### PR TITLE
TASKS: drop CORS, Docker and docs items

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -6,17 +6,11 @@ Open development tasks and decisions. Grows and shrinks as things land.
 
 ## Open
 
-- **CORS middleware in `ubdcc-restapi`** (upstream UBDCC): when
-  `ubdcc-restapi` sends `Access-Control-Allow-Origin: *` (behind a config
-  flag), this dashboard can run as a pure static `index.html` — no Python
-  proxy needed. The bundled `server.py` would then become an optional dev
-  launcher. Ship as an opt-in flag on the cluster side.
 - **Bulk endpoint `/get_all_depthcaches?levels=N`** in `ubdcc-restapi`:
   one request instead of `2 × N` for a full refresh. Unlocks sub-300 ms
-  refresh even for clusters with hundreds of DCs.
-- **Docker image** for quick one-liner deployments.
-- **Documentation**: Sphinx scaffolding exists; fill it with a real
-  user-guide once the CLI stabilises.
+  refresh even for clusters with hundreds of DCs. Server side still needs
+  discussion (DCN-side optimisations, payload shape) — once it lands on
+  the cluster side, switch the dashboard's polling path.
 
 ## Ideas (not committed)
 


### PR DESCRIPTION
Cleans up TASKS.md:
- CORS middleware: lives on the cluster side (if ever), not here.
- Docker image: unnecessary for a pip-installable CLI.
- Sphinx docs scaffolding: done and deployed.

Leaves only the Bulk-endpoint item (cluster-dependent) and the three parked ideas.