### PR TITLE
gitignore: drop docs/.buildinfo.bak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ wheelhouse/
 # Sphinx build artifacts (docs/ is the published output; the build dir is transient)
 dev/sphinx/build/
 dev/set_version.log
+docs/.buildinfo.bak
 
 # Environments
 .env

--- a/docs/.buildinfo.bak
+++ b/docs/.buildinfo.bak
@@ -1,4 +1,0 @@
-# Sphinx build info version 1
-# This file records the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 4875f8bd5b8ddb4f9b0d6caf9154ac37
-tags: 645f666f9bcd5a90fca523b33c5a78b7


### PR DESCRIPTION
Adds `docs/.buildinfo.bak` to .gitignore and removes the already-tracked copy. It's a transient sphinx build artifact that shouldn't be in the repo.