### PR TITLE
docs(llms.txt): add Docs URL to Links section

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -54,6 +54,7 @@ The dashboard is a client, not part of the cluster. It talks to a running UBDCC 
 ## Links
 
 - GitHub:        https://github.com/oliver-zehentleitner/ubdcc-dashboard
+- Docs:          https://oliver-zehentleitner.github.io/ubdcc-dashboard
 - PyPI:          https://pypi.org/project/ubdcc-dashboard
 - Issues:        https://github.com/oliver-zehentleitner/ubdcc-dashboard/issues
 - Changelog:     https://github.com/oliver-zehentleitner/ubdcc-dashboard/blob/master/CHANGELOG.md


### PR DESCRIPTION
## Summary
- The `Links` section in `llms.txt` listed GitHub, PyPI, Issues, Changelog and Telegram — but not the GitHub Pages docs URL
- UBDCC and UBS both list a `Docs:` entry in their llms.txt; this aligns ubdcc-dashboard with that convention
- Added `https://oliver-zehentleitner.github.io/ubdcc-dashboard`

## Test plan
- [ ] Read `llms.txt` — Docs URL appears directly below the GitHub link