### PR TITLE
feat(api-builder): add PHP and C/C++ snippets, link to issue tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/ubdcc-dashboard/readme.html#installation-and-upgrade)
 
 ## 0.2.1.dev (development stage/unreleased/unstable)
+### Added
+- API Builder: two more languages — **PHP** (built-in cURL extension,
+  no Composer required) and **C/C++** (libcurl, single template that
+  compiles with both `gcc` and `g++`). Brings the total to ten.
+- API Builder modal footer: link to
+  [Open an issue](https://github.com/oliver-zehentleitner/ubdcc-dashboard/issues)
+  next to the OpenAPI reference, so users can flag wrong snippets and
+  we can fix the generators.
 
 ## 0.2.0
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ Part of the [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unic
 - **API Builder** — onboarding helper for developers. Pick a task
   (create DepthCache, get asks/bids, add credentials, ...), fill in
   the form, copy a ready-to-paste snippet in **curl, HTTPie, Python
-  (using the [official UBLDC `Cluster` client](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache#connect-to-a-unicorn-binance-depthcache-cluster)), 
-  JavaScript, Go, C#,
-  Java or Rust**. "Try it" runs GET-safe tasks through the dashboard's
-  CORS proxy and shows the pretty-printed JSON response.
+  (using the [official UBLDC `Cluster` client](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache#connect-to-a-unicorn-binance-depthcache-cluster)),
+  JavaScript, Go, C#, Java, Rust, PHP or C/C++**. "Try it" runs
+  GET-safe tasks through the dashboard's CORS proxy and shows the
+  pretty-printed JSON response. Modal footer links to the cluster's
+  OpenAPI reference at `/docs` and to the dashboard's issue tracker
+  for snippet bug reports.
 - **Version badge** next to the title. On load, the dashboard asks
   PyPI for the latest release of `ubdcc-dashboard`. Up to date →
   badge stays in the accent colour. Outdated → animated rainbow

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/ubdcc-dashboard/readme.html#installation-and-upgrade)
 
 ## 0.2.1.dev (development stage/unreleased/unstable)
+### Added
+- API Builder: two more languages — **PHP** (built-in cURL extension,
+  no Composer required) and **C/C++** (libcurl, single template that
+  compiles with both `gcc` and `g++`). Brings the total to ten.
+- API Builder modal footer: link to
+  [Open an issue](https://github.com/oliver-zehentleitner/ubdcc-dashboard/issues)
+  next to the OpenAPI reference, so users can flag wrong snippets and
+  we can fix the generators.
 
 ## 0.2.0
 ### Added

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -47,9 +47,12 @@ Part of the [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unic
 - **API Builder** — onboarding helper for developers. Pick a task
   (create DepthCache, get asks/bids, add credentials, ...), fill in
   the form, copy a ready-to-paste snippet in **curl, HTTPie, Python
-  (using the official UBLDC `Cluster` client), JavaScript, Go, C#,
-  Java or Rust**. "Try it" runs GET-safe tasks through the dashboard's
-  CORS proxy and shows the pretty-printed JSON response.
+  (using the [official UBLDC `Cluster` client](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache#connect-to-a-unicorn-binance-depthcache-cluster)),
+  JavaScript, Go, C#, Java, Rust, PHP or C/C++**. "Try it" runs
+  GET-safe tasks through the dashboard's CORS proxy and shows the
+  pretty-printed JSON response. Modal footer links to the cluster's
+  OpenAPI reference at `/docs` and to the dashboard's issue tracker
+  for snippet bug reports.
 - **Version badge** next to the title. On load, the dashboard asks
   PyPI for the latest release of `ubdcc-dashboard`. Up to date →
   badge stays in the accent colour. Outdated → animated rainbow

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 > Monitor every depth cache in your cluster at a glance, spot out-of-sync caches, add or remove caches on the fly.
 > Inspect cluster health (pods, nodes, replica donuts) at a glance.
 > Manage Binance API credentials with a two-click-confirm UI.
-> Generate REST-API snippets for curl, HTTPie, Python (UBLDC client), JavaScript, Go, C#, Java, Rust — the API Builder.
+> Generate REST-API snippets for curl, HTTPie, Python (UBLDC client), JavaScript, Go, C#, Java, Rust, PHP, C/C++ — the API Builder.
 > Part of [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 
 Version: 0.2.0. Python 3.9 – 3.14.
@@ -64,7 +64,7 @@ The header has four connect-gated buttons besides `Disconnect`:
 - **Cluster ●** — live health dot (green = ok, yellow = degraded, red = unreachable / missing pods / DC slot shortfall). Backed by a 30 s `/get_cluster_info` poll. Modal shows pod-by-role groups, per-node topology, per-DC replica donut + sync state, credentials summary, mgmt version and DB-sync age. Manual `Refresh` button inside the modal.
 - **Credentials** — add / list / remove Binance API key pairs. `api_secret` input is masked; listed keys show only a preview. Remove is two-click confirm with 3 s auto-disarm.
 - **DepthCaches** — opens the Add-DepthCaches modal with live `exchangeInfo` symbol picker (spot, cross / isolated margin, futures, options — mainnet + testnets).
-- **API Builder** — 11 pre-built tasks (credentials, depthcaches, order book, cluster info) rendered as ready-to-paste REST-API calls in 8 languages. Python tab uses the official UBLDC `Cluster` client idiom (`BinanceLocalDepthCacheManager` context manager + `ubldc.cluster.<method>()`). Editable Base URL, `Try it →` for GET-safe tasks via the dashboard's CORS proxy, Copy button with secure-context + `execCommand` fallback.
+- **API Builder** — 11 pre-built tasks (credentials, depthcaches, order book, cluster info) rendered as ready-to-paste REST-API calls in 10 languages: curl, HTTPie, Python, JavaScript, Go, C#, Java, Rust, PHP, C/C++. Python tab uses the official UBLDC `Cluster` client idiom (`BinanceLocalDepthCacheManager` context manager + `ubldc.cluster.<method>()`). PHP uses the built-in cURL extension; C/C++ uses libcurl (`gcc … -lcurl` / `g++ … -lcurl`). Editable Base URL, `Try it →` for GET-safe tasks via the dashboard's CORS proxy, Copy button with secure-context + `execCommand` fallback. Modal footer links to the cluster's OpenAPI reference and to the dashboard's GitHub issue tracker for snippet bug reports.
 
 The header title also carries a **version badge** that queries PyPI once on load. Up to date → accent colour. Outdated → animated rainbow gradient with a `pip install -U ubdcc-dashboard` hint in the hover tooltip.
 

--- a/ubdcc_dashboard/static/index.html
+++ b/ubdcc_dashboard/static/index.html
@@ -706,8 +706,9 @@
       </section>
     </div>
     <footer>
-      <div class="hint" style="flex:1">
-        Full reference: <a id="bd_swagger_link" href="#" target="_blank">OpenAPI at <code>/docs</code></a>
+      <div class="hint" style="flex:1; line-height:1.6">
+        Full reference: <a id="bd_swagger_link" href="#" target="_blank">OpenAPI at <code>/docs</code></a><br>
+        Found a wrong snippet? <a href="https://github.com/oliver-zehentleitner/ubdcc-dashboard/issues" target="_blank" rel="noopener">Open an issue</a> so we can fix it.
       </div>
       <div><button id="bd_close" class="primary">Close</button></div>
     </footer>
@@ -1926,7 +1927,7 @@ const BUILDER_TASKS = [
   },
 ];
 
-const BUILDER_LANGS = ["curl", "HTTPie", "Python", "JavaScript", "Go", "C#", "Java", "Rust"];
+const BUILDER_LANGS = ["curl", "HTTPie", "Python", "JavaScript", "Go", "C#", "Java", "Rust", "PHP", "C/C++"];
 const builderState = {
   taskId: BUILDER_TASKS[0].id,
   lang: "curl",
@@ -2234,6 +2235,79 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }`;
 }
 
+function phpSingleQuote(s) {
+  // PHP single-quoted strings only escape \' and \\.
+  return "'" + String(s).replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "'";
+}
+
+function snippetPHP(task, baseUrl, values) {
+  // Uses PHP's built-in cURL extension — no Composer required.
+  const url = baseUrl + task.path;
+  if (task.body) {
+    const json = JSON.stringify(values);
+    return `<?php
+$body = ${phpSingleQuote(json)};
+$ch = curl_init(${phpSingleQuote(url)});
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+    CURLOPT_POSTFIELDS => $body,
+]);
+$response = curl_exec($ch);
+curl_close($ch);
+echo $response;`;
+  }
+  const full = url + buildQueryString(values);
+  return `<?php
+$ch = curl_init(${phpSingleQuote(full)});
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+$response = curl_exec($ch);
+curl_close($ch);
+echo $response;`;
+}
+
+function snippetC(task, baseUrl, values) {
+  // libcurl works for both C and C++ (and is the standard way to do HTTP in C).
+  const url = baseUrl + task.path;
+  if (task.body) {
+    const json = JSON.stringify(values);
+    return `// gcc main.c -lcurl    (or g++ main.cpp -lcurl)
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main(void) {
+    CURL *curl = curl_easy_init();
+    if (!curl) return 1;
+    const char *body = "${escStrBackslash(json)}";
+    struct curl_slist *headers = NULL;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+    curl_easy_setopt(curl, CURLOPT_URL, "${escStrBackslash(url)}");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+    CURLcode rc = curl_easy_perform(curl);
+    if (rc != CURLE_OK) fprintf(stderr, "curl: %s\\n", curl_easy_strerror(rc));
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    return 0;
+}`;
+  }
+  const full = url + buildQueryString(values);
+  return `// gcc main.c -lcurl    (or g++ main.cpp -lcurl)
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main(void) {
+    CURL *curl = curl_easy_init();
+    if (!curl) return 1;
+    curl_easy_setopt(curl, CURLOPT_URL, "${escStrBackslash(full)}");
+    CURLcode rc = curl_easy_perform(curl);
+    if (rc != CURLE_OK) fprintf(stderr, "curl: %s\\n", curl_easy_strerror(rc));
+    curl_easy_cleanup(curl);
+    return 0;
+}`;
+}
+
 const SNIPPET_GEN = {
   "curl": snippetCurl,
   "HTTPie": snippetHTTPie,
@@ -2243,6 +2317,8 @@ const SNIPPET_GEN = {
   "C#": snippetCSharp,
   "Java": snippetJava,
   "Rust": snippetRust,
+  "PHP": snippetPHP,
+  "C/C++": snippetC,
 };
 
 function renderBuilderTaskList() {


### PR DESCRIPTION
## Summary

Two extensions to the API Builder:

1. Two new language tabs — **PHP** and **C/C++**.
2. Modal footer now links to the dashboard's **issue tracker** so users can report wrong snippets and we can fix the generators.

## Languages

### PHP
Uses the built-in `cURL` extension. No Composer, no third-party dependency. Same shape as the existing C# / Java tabs (single template, no helper functions to copy around).

```php
<?php
$body = '{"exchange":"binance.com","market":"BTCUSDT","desired_quantity":2}';
$ch = curl_init('http://127.0.0.1:42081/create_depthcaches');
curl_setopt_array($ch, [
    CURLOPT_RETURNTRANSFER => true,
    CURLOPT_POST => true,
    CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
    CURLOPT_POSTFIELDS => $body,
]);
$response = curl_exec($ch);
curl_close($ch);
echo $response;
```

### C/C++
One libcurl template that compiles with both `gcc main.c -lcurl` and `g++ main.cpp -lcurl`. Single tab covers both languages because the libcurl call shape is identical.

```c
// gcc main.c -lcurl    (or g++ main.cpp -lcurl)
#include <stdio.h>
#include <curl/curl.h>

int main(void) {
    CURL *curl = curl_easy_init();
    if (!curl) return 1;
    curl_easy_setopt(curl, CURLOPT_URL, "http://127.0.0.1:42081/get_cluster_info");
    CURLcode rc = curl_easy_perform(curl);
    if (rc != CURLE_OK) fprintf(stderr, "curl: %s\n", curl_easy_strerror(rc));
    curl_easy_cleanup(curl);
    return 0;
}
```

Total snippet languages now: **10** — curl, HTTPie, Python, JavaScript, Go, C#, Java, Rust, PHP, C/C++.

## Issue tracker link

Modal footer:

> Full reference: OpenAPI at `/docs`
> Found a wrong snippet? **Open an issue** so we can fix it.

Lowers the friction for users to report generator bugs — there are now ten code paths, drift is inevitable.

## Files

- `ubdcc_dashboard/static/index.html` — `BUILDER_LANGS` extended; new `phpSingleQuote`, `snippetPHP`, `snippetC`; `SNIPPET_GEN` wired up; footer link added
- `CHANGELOG.md` — entry under `0.2.1.dev`
- `README.md` + `dev/sphinx/source/readme.md` — Features list mentions PHP / C/C++ + issue link
- `llms.txt` — hook + Feature modals section list updated

No version bump — this is dev-stage work toward 0.3.0 (or whatever the next minor lands as).