### PR TITLE
docs(readme): mention UBDCC 0.7.1+ bundles the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ pip install -U ubdcc-dashboard
 Requires Python 3.9+. No external dependencies — uses only the standard
 library.
 
+> **Already running the cluster?** Since UBDCC `0.7.1`, `pip install ubdcc`
+> bundles `ubdcc-dashboard` automatically — no separate install step needed.
+> Standalone install is still useful when you want the dashboard on a
+> different machine than the cluster, or pinned to a specific version.
+
 **Cluster target:** UBDCC ≥ 0.7.0 (with UBLDC ≥ 2.14.0 for margin /
 isolated-margin support). Older clusters work for the orderbook view
 but reject the renamed credential endpoints used by the Credentials

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -47,7 +47,8 @@ Part of the [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unic
 - **API Builder** — onboarding helper for developers. Pick a task
   (create DepthCache, get asks/bids, add credentials, ...), fill in
   the form, copy a ready-to-paste snippet in **curl, HTTPie, Python
-  (using the official UBLDC `Cluster` client), JavaScript, Go, C#,
+  (using the [official UBLDC `Cluster` client](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache#connect-to-a-unicorn-binance-depthcache-cluster)), 
+  JavaScript, Go, C#,
   Java or Rust**. "Try it" runs GET-safe tasks through the dashboard's
   CORS proxy and shows the pretty-printed JSON response.
 - **Version badge** next to the title. On load, the dashboard asks
@@ -94,6 +95,11 @@ pip install -U ubdcc-dashboard
 
 Requires Python 3.9+. No external dependencies — uses only the standard
 library.
+
+> **Already running the cluster?** Since UBDCC `0.7.1`, `pip install ubdcc`
+> bundles `ubdcc-dashboard` automatically — no separate install step needed.
+> Standalone install is still useful when you want the dashboard on a
+> different machine than the cluster, or pinned to a specific version.
 
 **Cluster target:** UBDCC ≥ 0.7.0 (with UBLDC ≥ 2.14.0 for margin /
 isolated-margin support). Older clusters work for the orderbook view


### PR DESCRIPTION
## Summary

Companion to oliver-zehentleitner/unicorn-binance-depth-cache-cluster#143, which bundles `ubdcc-dashboard` as a runtime dependency of the `ubdcc` CLI package.

After both PRs land, users running the cluster via `pip install ubdcc` get the dashboard for free — no second install step. This README note tells them.

## Files

- `README.md` — short callout in the Installation section
- `dev/sphinx/source/readme.md` — mirrored

`pip install -U ubdcc-dashboard` stays as the primary install command at the top, since it's still the right path for standalone / different-machine / version-pinned setups.