### PR TITLE
docs(readme): drop version-specific compatibility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,10 @@ pip install -U ubdcc-dashboard
 Requires Python 3.9+. No external dependencies — uses only the standard
 library.
 
-> **Already running the cluster?** Since UBDCC `0.7.1`, `pip install ubdcc`
-> bundles `ubdcc-dashboard` automatically — no separate install step needed.
+> **Already running the cluster?** `pip install ubdcc` bundles
+> `ubdcc-dashboard` automatically — no separate install step needed.
 > Standalone install is still useful when you want the dashboard on a
 > different machine than the cluster, or pinned to a specific version.
-
-**Cluster target:** UBDCC ≥ 0.7.0 (with UBLDC ≥ 2.14.0 for margin /
-isolated-margin support). Older clusters work for the orderbook view
-but reject the renamed credential endpoints used by the Credentials
-manager and the API Builder.
 
 ---
 

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -98,15 +98,10 @@ pip install -U ubdcc-dashboard
 Requires Python 3.9+. No external dependencies — uses only the standard
 library.
 
-> **Already running the cluster?** Since UBDCC `0.7.1`, `pip install ubdcc`
-> bundles `ubdcc-dashboard` automatically — no separate install step needed.
+> **Already running the cluster?** `pip install ubdcc` bundles
+> `ubdcc-dashboard` automatically — no separate install step needed.
 > Standalone install is still useful when you want the dashboard on a
 > different machine than the cluster, or pinned to a specific version.
-
-**Cluster target:** UBDCC ≥ 0.7.0 (with UBLDC ≥ 2.14.0 for margin /
-isolated-margin support). Older clusters work for the orderbook view
-but reject the renamed credential endpoints used by the Credentials
-manager and the API Builder.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -55,8 +55,6 @@ Proxy endpoints (for agents wanting to script against the launcher):
 
 The dashboard is a client, not part of the cluster. It talks to a running UBDCC cluster via its public REST API (typical URL: `http://<cluster-host>:42081`). See https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster for the cluster itself.
 
-**Cluster target:** UBDCC >= 0.7.0 (and UBLDC >= 2.14.0 for margin / isolated-margin support). Older clusters render the orderbook view fine but reject the renamed credential endpoints used by the Credentials manager and the API Builder.
-
 ## Feature modals
 
 The header has four connect-gated buttons besides `Disconnect`:


### PR DESCRIPTION
## Summary

Project is still young and just leaving beta — readme should describe
the current state, not historical upgrade paths.

- Removed the **Cluster target: UBDCC >= 0.7.0 ...** paragraph from
  `README.md`, the sphinx mirror, and `llms.txt`.
- Dropped the **Since UBDCC 0.7.1** lead-in from the *Already running
  the cluster?* callout. The callout itself stays — it's a useful hint
  that `pip install ubdcc` bundles the dashboard.

## Test plan
- [ ] Render `README.md` on GitHub and confirm the Installation section
      reads cleanly without the removed paragraph.
- [ ] Build sphinx docs locally and confirm the mirror reflects the
      same change.