### PR TITLE
release(0.3.1): fix empty-state message not toggling on add/remove

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -57,7 +57,7 @@ jobs:
           generate_release_notes: true
           name: ubdcc-dashboard
           prerelease: false
-          tag_name: 0.3.0
+          tag_name: 0.3.1
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ as a pip-installable CLI (`ubdcc-dashboard start`) for the
 [UNICORN Binance DepthCache Cluster (UBDCC)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster).
 
 **Abbreviation:** ubdcc-dashboard
-**Current Version:** 0.3.0
+**Current Version:** 0.3.1
 **Author:** Oliver Zehentleitner
 **Python:** 3.9-3.14 on Linux, macOS, Windows
 **Dependencies:** none (stdlib only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/ubdcc-dashboard/readme.html#installation-and-upgrade)
 
-## 0.3.0.dev (development stage/unreleased/unstable)
+## 0.3.1.dev (development stage/unreleased/unstable)
+
+## 0.3.1
+### Fixed
+- Main grid empty-state message ("No DepthCaches configured yet —
+  click `DepthCaches` to add one.") was set only once in `connect()`
+  and never re-evaluated. After creating the first DepthCache the
+  hint stayed visible behind the new tiles until the user hit F5;
+  removing the last DepthCache left the area blank without the
+  hint. Moved the toggle into `reloadDcs()` so the message reflects
+  the current `state.dcs.length` after every add / remove / initial
+  reload.
 
 ## 0.3.0
 ### Added

--- a/dev/set_version_config.yml
+++ b/dev/set_version_config.yml
@@ -8,4 +8,4 @@ files:
 - ubdcc_dashboard/__init__.py
 - AGENTS.md
 - README.md
-version: 0.3.0
+version: 0.3.1

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -9,7 +9,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/ubdcc-dashboard/readme.html#installation-and-upgrade)
 
-## 0.3.0.dev (development stage/unreleased/unstable)
+## 0.3.1.dev (development stage/unreleased/unstable)
+
+## 0.3.1
+### Fixed
+- Main grid empty-state message ("No DepthCaches configured yet —
+  click `DepthCaches` to add one.") was set only once in `connect()`
+  and never re-evaluated. After creating the first DepthCache the
+  hint stayed visible behind the new tiles until the user hit F5;
+  removing the last DepthCache left the area blank without the
+  hint. Moved the toggle into `reloadDcs()` so the message reflects
+  the current `state.dcs.length` after every add / remove / initial
+  reload.
 
 ## 0.3.0
 ### Added

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -15,7 +15,7 @@ author = 'Oliver Zehentleitner'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.3.0'
+release = '0.3.1'
 
 html_last_updated_fmt = "%b %d %Y at %H:%M (CET)"
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 > Generate REST-API snippets for curl, HTTPie, Python (UBLDC client), JavaScript, Go, C#, Java, Rust, PHP, C/C++ — the API Builder.
 > Part of [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 
-Version: 0.3.0. Python 3.9 – 3.14.
+Version: 0.3.1. Python 3.9 – 3.14.
 
 ## Authorship & License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc-dashboard"
-version = "0.3.0"
+version = "0.3.1"
 description = "Browser-based live dashboard for the UNICORN Binance DepthCache Cluster (UBDCC) — monitor and manage depth caches in real time."
 authors = ["Oliver Zehentleitner"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="ubdcc-dashboard",
-    version="0.3.0",
+    version="0.3.1",
     author="Oliver Zehentleitner",
     author_email="",
     url="https://github.com/oliver-zehentleitner/ubdcc-dashboard",

--- a/ubdcc_dashboard/__init__.py
+++ b/ubdcc_dashboard/__init__.py
@@ -1,3 +1,3 @@
 """UBDCC Dashboard — browser-based live dashboard for the UNICORN Binance DepthCache Cluster."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/ubdcc_dashboard/static/index.html
+++ b/ubdcc_dashboard/static/index.html
@@ -1074,6 +1074,13 @@ async function reloadDcs() {
   }
   rebuildExchangeFilter();
   applyFilter();
+  const emptyEl = document.getElementById("empty");
+  if (state.dcs.length) {
+    emptyEl.style.display = "none";
+  } else {
+    emptyEl.innerHTML = 'No DepthCaches configured yet — click <code>DepthCaches</code> to add one.';
+    emptyEl.style.display = "";
+  }
 }
 
 function renderBook(body, asks, bids) {
@@ -1188,13 +1195,6 @@ async function connect() {
   }, { rootMargin: "200px" });
 
   await reloadDcs();
-  const emptyEl = document.getElementById("empty");
-  if (state.dcs.length) {
-    emptyEl.style.display = "none";
-  } else {
-    emptyEl.innerHTML = 'No DepthCaches configured yet — click <code>DepthCaches</code> to add one.';
-    emptyEl.style.display = "";
-  }
   document.getElementById("addBtn").disabled = false;
   document.getElementById("disconnectBtn").disabled = false;
   document.getElementById("clusterStatusBtn").disabled = false;


### PR DESCRIPTION
## Summary

Patch release **0.3.0 → 0.3.1**. One bug fix.

## Bug

The main grid empty-state hint (*"No DepthCaches configured yet —
click `DepthCaches` to add one."*) was set once in `connect()` and
never re-evaluated. After creating the first DepthCache it stayed
visible behind the new tiles until the user hit **F5**; removing the
last DepthCache left the area blank without the hint coming back.

## Fix

Moved the empty-state toggle out of `connect()` and into
`reloadDcs()`, so the message reflects the current `state.dcs.length`
after every add / remove / initial reload — no F5 needed. Single
source of truth.

## Version bump

0.3.0 → 0.3.1 across the 9 files in `dev/set_version_config.yml` plus
the sphinx changelog mirror. CHANGELOG: empty `0.3.1.dev` placeholder
+ new `0.3.1` section.

## Out of scope

`docs/` deliberately untouched — Oliver rebuilds and releases.

## Test plan
- [x] Connect with empty cluster → message visible.
- [x] Add first DepthCache → message hides without F5.
- [x] Remove all DepthCaches → message reappears without F5.
- [ ] Oliver rebuilds docs + PyPI release + GitHub tag.