### PR TITLE
docs(README): add depthcache rot + UBDCC deep-dive articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ REST API.
 
 ## Related Articles
 - [From `pip install` to a Redundant Binance Order Book Cluster — UBDCC + Dashboard Quickstart](https://blog.technopathy.club/from-pip-install-to-a-redundant-binance-order-book-cluster-ubdcc-dashboard-quickstart)
+- [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours)
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books)
 - [UNICORN Binance Suite Article Series](https://blog.technopathy.club/series/unicorn-binance-suite)
 
 ## Project Homepage

--- a/llms.txt
+++ b/llms.txt
@@ -74,3 +74,8 @@ The header title also carries a **version badge** that queries PyPI once on load
 - Issues:        https://github.com/oliver-zehentleitner/ubdcc-dashboard/issues
 - Changelog:     https://github.com/oliver-zehentleitner/ubdcc-dashboard/blob/master/CHANGELOG.md
 - Telegram:      https://t.me/unicorndevs
+
+## Related Articles
+
+- [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours) — 25-hour experiment that motivates UBDCC's freshness model (the dashboard visualizes the resulting health/sync state).
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books) — architecture write-up of the trust-layer that the dashboard surfaces.


### PR DESCRIPTION
## Summary
- Add two new technopathy.club articles to the *Related Articles* section.

## New links
- https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours
- https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books

The rot experiment motivates UBDCC's freshness model the dashboard visualizes; the deep-dive describes the trust-layer architecture itself.

## Test plan
- [x] README renders correctly on GitHub
- [x] Link targets are reachable