### PR TITLE
docs(readme): merge intro paragraphs to remove duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@
 # UBDCC Dashboard
 
 Browser-based live dashboard for the [UNICORN Binance DepthCache Cluster (UBDCC)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) —
-monitor every depth cache in your cluster at a glance, spot out-of-sync caches
-instantly, and add or remove caches on the fly.
-
-The dashboard provides a compact live view of your UBDCC cluster in the browser: mini-orderbook tiles, sync/error state 
-visibility, and quick DepthCache management in one place.
+your whole cluster at a glance, with mini-orderbook tiles per cache, instant sync/error
+visibility, and add or remove caches on the fly.
 
 ![UBDCC Dashboard Screenshot](https://raw.githubusercontent.com/oliver-zehentleitner/ubdcc-dashboard/refs/heads/master/images/misc/ubdcc-dashboard.png)
 


### PR DESCRIPTION
## Summary
- Two intro paragraphs above the screenshot overlapped heavily (browser, live, view caches, sync visibility, add/remove); only "mini-orderbook tiles" was unique to the second
- Merged into a single tighter sentence that keeps the unique detail

## Test plan
- [ ] README renders correctly on github.com
- [ ] Intro reads cleanly above the screenshot