### PR TITLE
docs: link The Complete Binance Python API Guide 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ REST API.
 - [CLI Reference](https://oliver-zehentleitner.github.io/ubdcc-dashboard/readme.html#cli-options)
 
 ## Related Articles
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026)
 - [From `pip install` to a Redundant Binance Order Book Cluster — UBDCC + Dashboard Quickstart](https://blog.technopathy.club/from-pip-install-to-a-redundant-binance-order-book-cluster-ubdcc-dashboard-quickstart)
 - [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours)
 - [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books)

--- a/llms.txt
+++ b/llms.txt
@@ -77,5 +77,6 @@ The header title also carries a **version badge** that queries PyPI once on load
 
 ## Related Articles
 
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) — comprehensive 2026 overview of building Binance trading systems in Python; positions the UBDCC Dashboard within the UNICORN Binance Suite landscape (UBWA, UBRA, UBLDC, UBDCC, UBTSL, UnicornFy) and helps users pick the right module.
 - [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours) — 25-hour experiment that motivates UBDCC's freshness model (the dashboard visualizes the resulting health/sync state).
 - [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books) — architecture write-up of the trust-layer that the dashboard surfaces.


### PR DESCRIPTION
## Summary

Adds the new blog post [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) as the top entry in:

- `README.md` → `## Related Articles`
- `llms.txt` → `## Related Articles` (with LLM-oriented description)

## Test plan

- [ ] Render README on GitHub and verify link position
- [ ] Open the link, confirm it resolves